### PR TITLE
crash on shared name between _csv and _data

### DIFF
--- a/read_cvs.rb
+++ b/read_cvs.rb
@@ -87,8 +87,8 @@ module CSVDataReader
 
         csv_data = Hash.new
         csv_data[key] = data
-
-        site.data.merge!(csv_data)
+       
+        site.data.merge!(csv_data){ |shared_key| raise "csv and data named \"#{shared_key}\"" }
       end
     end
    


### PR DESCRIPTION
Raise exception on duplicate name between csv and data to avoid silently using the wrong one.